### PR TITLE
Add support for ProtocolAdapter feature

### DIFF
--- a/docker-compose/config/hal-interface-adapter/config-no-kuksa/config.json
+++ b/docker-compose/config/hal-interface-adapter/config-no-kuksa/config.json
@@ -1,9 +1,20 @@
 {
     "loglevel": "INFO",
     "iotea": {
-        "mqtt": {
-            "connectionString": "mqtt://mosquitto:1883",
-            "ns": "iotea/"
+        "protocolGateway": {
+            "adapters": [
+                {
+                    "platform": true,
+                    "module": {
+                        "name": "./util/mqttClient",
+                        "class": "MqttProtocolAdapter"
+                    },
+                    "config": {
+                        "topicNamespace": "iotea/",
+                        "brokerUrl": "mqtt://mosquitto:1883"
+                    }
+                }
+            ]
         },
         "subject": "anyone",
         "instance": "anyinstance"
@@ -18,9 +29,20 @@
         }
     },
     "hal": {
-        "mqtt": {
-            "connectionString": "mqtt://mosquitto:1883",
-            "ns": "hal/"
+        "protocolGateway": {
+            "adapters": [
+                {
+                    "platform": true,
+                    "module": {
+                        "name": "./util/mqttClient",
+                        "class": "MqttProtocolAdapter"
+                    },
+                    "config": {
+                        "topicNamespace": "hal/",
+                        "brokerUrl": "mqtt://mosquitto:1883"
+                    }
+                }
+            ]
         }
     }
 }

--- a/docker-compose/config/hal-interface-adapter/config/config.json
+++ b/docker-compose/config/hal-interface-adapter/config/config.json
@@ -1,9 +1,20 @@
 {
     "loglevel": "INFO",
     "iotea": {
-        "mqtt": {
-            "connectionString": "mqtt://mosquitto:1883",
-            "ns": "iotea/"
+        "protocolGateway": {
+            "adapters": [
+                {
+                    "platform": true,
+                    "module": {
+                        "name": "./util/mqttClient",
+                        "class": "MqttProtocolAdapter"
+                    },
+                    "config": {
+                        "topicNamespace": "iotea/",
+                        "brokerUrl": "mqtt://mosquitto:1883"
+                    }
+                }
+            ]
         },
         "subject": "anyone",
         "instance": "anyinstance"
@@ -20,9 +31,20 @@
         }
     },
     "hal": {
-        "mqtt": {
-            "connectionString": "mqtt://mosquitto:1883",
-            "ns": "hal/"
+        "protocolGateway": {
+            "adapters": [
+                {
+                    "platform": true,
+                    "module": {
+                        "name": "./util/mqttClient",
+                        "class": "MqttProtocolAdapter"
+                    },
+                    "config": {
+                        "topicNamespace": "hal/",
+                        "brokerUrl": "mqtt://mosquitto:1883"
+                    }
+                }
+            ]
         }
     }
 }

--- a/docker-compose/config/hal-interface/config.json
+++ b/docker-compose/config/hal-interface/config.json
@@ -24,8 +24,7 @@
                 },
                 "config": {
                     "topicNamespace": "hal/",
-                    "mqtt5Only": false,
-                    "brokerUrl": "mqtt://mosquitto-local:1883"
+                    "brokerUrl": "mqtt://mosquitto:1883"
                 }
             }
         ]

--- a/docker-compose/config/hal-interface/config.json
+++ b/docker-compose/config/hal-interface/config.json
@@ -14,8 +14,20 @@
             }
         }
     ],
-    "mqtt": {
-        "connectionString": "mqtt://mosquitto:1883",
-        "ns": "hal/"
+    "protocolGateway": {
+        "adapters": [
+            {
+                "platform": true,
+                "module": {
+                    "name": ".util.mqtt_client",
+                    "class": "MqttProtocolAdapter"
+                },
+                "config": {
+                    "topicNamespace": "hal/",
+                    "mqtt5Only": false,
+                    "brokerUrl": "mqtt://mosquitto-local:1883"
+                }
+            }
+        ]
     }
 }

--- a/docker-compose/config/kuksa.val/README.md
+++ b/docker-compose/config/kuksa.val/README.md
@@ -25,8 +25,8 @@ You can find out, where to get these files [here](https://github.com/GENIVI/iot-
 You can also run the helper script to generate vss.json, add required values and download kuksa.val certs:
 ```code
 cd vehicle-edge/setup/general/kuksa.val
-./generate-vss.sh
-cp vss-mod.json ../../../docker-compose/config/kuksa.val/vss.json
-cp -r certs ../../../docker-compose/config/kuksa.val/
+./generate-config.sh
+cp config/vss-mod.json ../../../docker-compose/config/kuksa.val/vss.json
+cp -r config/certs ../../../docker-compose/config/kuksa.val/
 ```
 

--- a/docker-compose/docker-compose.kuksa.val.yml
+++ b/docker-compose/docker-compose.kuksa.val.yml
@@ -23,7 +23,7 @@ services:
       context: ../iot-event-analytics
       labels:
         arch: ${ARCH-amd64}
-      dockerfile: ../iot-event-analytics/docker/kuksa.val2iotea/Dockerfile.${ARCH-amd64}
+      dockerfile: docker/kuksa.val2iotea/Dockerfile.${ARCH-amd64}
       args:
         - HTTP_PROXY=${DOCKER_HTTP_PROXY}
         - HTTPS_PROXY=${DOCKER_HTTPS_PROXY}

--- a/setup/general/hal-interface-adapter/README.md
+++ b/setup/general/hal-interface-adapter/README.md
@@ -70,9 +70,20 @@
   {
     "loglevel": "DEBUG",                                    // Can be VERBOSE, DEBUG, INFO, WARN, ERROR
     "iotea": {
-      "mqtt": {
-        "connectionString": "mqtt://localhost:1883",
-        "ns": "iotea/"
+      "protocolGateway": {
+        "adapters": [
+          {
+            "platform": true,
+            "module": {
+              "name": "./util/mqttClient",
+              "class": "MqttProtocolAdapter"
+            },
+            "config": {
+              "topicNamespace": "iotea/",
+              "brokerUrl": "mqtt://mosquitto:1883"
+            }
+          }
+        ]
       },
       "subject": "<Some userId>",                           // Mandatory, if Kuksa.VAL should be bypasseed, vss.ws is not given and/or vss.subjectPath is undefined
       "instance": "<The VIN, or serial number>"             // Mandatory, if Kuksa.VAL should be bypasseed, vss.ws is not given and/or vss.instancePath is undefined
@@ -99,9 +110,20 @@
       }
     },
     "hal": {
-      "mqtt": {
-        "connectionString": "mqtt://localhost:1883",
-        "ns": "hal/"
+      "protocolGateway": {
+          "adapters": [
+              {
+                  "platform": true,
+                  "module": {
+                      "name": "./util/mqttClient",
+                      "class": "MqttProtocolAdapter"
+                  },
+                  "config": {
+                      "topicNamespace": "hal/",
+                      "brokerUrl": "mqtt://mosquitto:1883"
+                  }
+              }
+          ]
       }
     }
   }

--- a/setup/general/hal-interface-adapter/config-no-kuksa/config.json
+++ b/setup/general/hal-interface-adapter/config-no-kuksa/config.json
@@ -1,9 +1,20 @@
 {
-    "loglevel": "DEBUG",
+    "loglevel": "INFO",
     "iotea": {
-        "mqtt": {
-            "connectionString": "mqtt://localhost:1883",
-            "ns": "iotea/"
+        "protocolGateway": {
+            "adapters": [
+                {
+                    "platform": true,
+                    "module": {
+                        "name": "./util/mqttClient",
+                        "class": "MqttProtocolAdapter"
+                    },
+                    "config": {
+                        "topicNamespace": "iotea/",
+                        "brokerUrl": "mqtt://mosquitto:1883"
+                    }
+                }
+            ]
         },
         "subject": "anyone",
         "instance": "anyinstance"
@@ -18,9 +29,20 @@
         }
     },
     "hal": {
-        "mqtt": {
-            "connectionString": "mqtt://localhost:1883",
-            "ns": "hal/"
+        "protocolGateway": {
+            "adapters": [
+                {
+                    "platform": true,
+                    "module": {
+                        "name": "./util/mqttClient",
+                        "class": "MqttProtocolAdapter"
+                    },
+                    "config": {
+                        "topicNamespace": "hal/",
+                        "brokerUrl": "mqtt://mosquitto:1883"
+                    }
+                }
+            ]
         }
     }
 }

--- a/setup/general/hal-interface-adapter/config/config.json
+++ b/setup/general/hal-interface-adapter/config/config.json
@@ -1,5 +1,5 @@
 {
-    "loglevel": "DEBUG",
+    "loglevel": "INFO",
     "iotea": {
         "protocolGateway": {
             "adapters": [
@@ -11,15 +11,18 @@
                     },
                     "config": {
                         "topicNamespace": "iotea/",
-                        "brokerUrl": "mqtt://mosquitto-local:1883"
+                        "brokerUrl": "mqtt://mosquitto:1883"
                     }
                 }
             ]
+        },
+        "subject": "anyone",
+        "instance": "anyinstance"
     },
     "kuksa.val": {
+        "ws": "ws://kuksa.val:8090",
+        "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJrdWtzYS52YWwiLCJpc3MiOiJFY2xpcHNlIEtVS1NBIERldiIsImFkbWluIjp0cnVlLCJtb2RpZnlUcmVlIjp0cnVlLCJpYXQiOjE1MTYyMzkwMjIsImV4cCI6MTY1NDY4ODE2NSwia3Vrc2EtdnNzIjp7IioiOiJydyJ9fQ.CsTbYO_Xb8EmPU5PWKmsBpbx9LoOQXZjL9NwdEKrDR4g-Ky1vAQ5Rrst17gTb3zEUWNC2-UbVPNA38qttCrN3f2uQTTFQbevx2UVP42OWzbddUplAAcjxTvz3kGmQxKeR8Ijs7fPCHogK_nw9V9O9FO2cGPfKVrhV_JpD5sf9iM_RfbqwyWjBJ3Vo7zj5slWnFD9w6MZdAQbBVp_QjYJwH5B02QFJ0AS7urmCgInRnzxjayH_Z74Bu1RROrUxe1HyCPMcd8xnlTcoh-wCxotYj-Rg3t9mQY2ywG59Bq0T1pMocJ_5Jx4_5zSNF2JU3H8FL_iP0OjzljoBpK89qzOVYVepEmAo9W6ze1JXjxQo5WH6C0fsjo6gJMVCJ5fnUCm5cP6FPIwV_pN00bQKrFxulGP7gigSO2a__CDv4EdbdquJPktSK4LtAO0MqFbWxPlkggnwz59fqqCaJ1fpcywtkRWHCCui3a80eE7wllGthGkNhjqB9a4xB8DOYzpMYjhmY9_E5WvXY4WHq_rTTpHhKf3xja66Z8y4NVp_P4a7_gWy8LRzQThdX2wpXosVRPFsa2dHjSL4bwvSi_tdgkRajXI6G2KFMFkbrWP6hfab5GhIOKDOp2TNp0b5Ff2vJsuqfQrBVF63NzefKMNYNc0NT_CfVwQDtZJkLegZDaV1JU",
         "bypass": false,
-        "ws": "ws://localhost:8090",
-        "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJrdWtzYS52YWwiLCJpc3MiOiJFY2xpcHNlIEtVS1NBIERldiIsImFkbWluIjp0cnVlLCJtb2RpZnlUcmVlIjp0cnVlLCJpYXQiOjE1MTYyMzkwMjIsImV4cCI6MTc2NzIyNTU5OSwia3Vrc2EtdnNzIjp7IioiOiJydyJ9fQ.p2cnFGH16QoQ14l6ljPVKggFXZKmD-vrw8G6Vs6DvAokjsUG8FHh-F53cMsE-GDjyZH_1_CrlDCnbGlqjsFbgAylqA7IAJWp9_N6dL5p8DHZTwlZ4IV8L1CtCALs7XVqvcQKHCCzB63Y8PgVDCAqpQSRb79JPVD4pZwkBKpOknfEY5y9wfbswZiRKdgz7o61_oFnd-yywpse-23HD6v0htThVF1SuGL1PuvGJ8p334nt9bpkZO3gaTh1xVD_uJMwHzbuBCF33_f-I5QMZO6bVooXqGfe1zvl3nDrPEjq1aPulvtP8RgREYEqE6b2hB8jouTiC_WpE3qrdMw9sfWGFbm04qC-2Zjoa1yYSXoxmYd0SnliSYHAad9aXoEmFENezQV-of7sc-NX1-2nAXRAEhaqh0IRuJwB4_sG7SvQmnanwkz-sBYxKqkoFpOsZ6hblgPDOPYY2NAsZlYkjvAL2mpiInrsmY_GzGsfwPeAx31iozImX75rao8rm-XucAmCIkRlpBz6MYKCjQgyRz3UtZCJ2DYF4lKqTjphEAgclbYZ7KiCuTn9HualwtEmVzHHFneHMKl7KnRQk-9wjgiyQ5nlsVpCCblg6JKr9of4utuPO3cBvbjhB4_ueQ40cpWVOICcOLS7_w0i3pCq1ZKDEMrYDJfz87r2sU9kw1zeFQk",
         "pathConfig": {
             "separator": ".",
             "replacer": {
@@ -38,7 +41,7 @@
                     },
                     "config": {
                         "topicNamespace": "hal/",
-                        "brokerUrl": "mqtt://mosquitto-local:1883"
+                        "brokerUrl": "mqtt://mosquitto:1883"
                     }
                 }
             ]

--- a/setup/general/hal-interface-adapter/config/config.json
+++ b/setup/general/hal-interface-adapter/config/config.json
@@ -1,10 +1,20 @@
 {
     "loglevel": "DEBUG",
     "iotea": {
-        "mqtt": {
-            "connectionString": "mqtt://localhost:1883",
-            "ns": "iotea/"
-        }
+        "protocolGateway": {
+            "adapters": [
+                {
+                    "platform": true,
+                    "module": {
+                        "name": "./util/mqttClient",
+                        "class": "MqttProtocolAdapter"
+                    },
+                    "config": {
+                        "topicNamespace": "iotea/",
+                        "brokerUrl": "mqtt://mosquitto-local:1883"
+                    }
+                }
+            ]
     },
     "kuksa.val": {
         "bypass": false,
@@ -18,9 +28,20 @@
         }
     },
     "hal": {
-        "mqtt": {
-            "connectionString": "mqtt://localhost:1883",
-            "ns": "hal/"
+        "protocolGateway": {
+            "adapters": [
+                {
+                    "platform": true,
+                    "module": {
+                        "name": "./util/mqttClient",
+                        "class": "MqttProtocolAdapter"
+                    },
+                    "config": {
+                        "topicNamespace": "hal/",
+                        "brokerUrl": "mqtt://mosquitto-local:1883"
+                    }
+                }
+            ]
         }
     }
 }

--- a/setup/general/hal-interface/README.md
+++ b/setup/general/hal-interface/README.md
@@ -94,9 +94,20 @@ Configure start of mock, by setting _interface_ property in _config.json_ to "mo
             }
         }
     ],
-    "mqtt": {
-        "connectionString": "mqtt://localhost:1883",
-        "ns": "hal/"
+    "protocolGateway": {
+        "adapters": [
+            {
+                "platform": true,
+                "module": {
+                    "name": ".util.mqtt_client",
+                    "class": "MqttProtocolAdapter"
+                },
+                "config": {
+                    "topicNamespace": "hal/",
+                    "brokerUrl": "mqtt://mosquitto:1883"
+                }
+            }
+        ]
     }
 }
 ```

--- a/setup/general/hal-interface/config/config.json
+++ b/setup/general/hal-interface/config/config.json
@@ -17,8 +17,19 @@
             }
         }
     ],
-    "mqtt": {
-        "connectionString": "mqtt://localhost:1883",
-        "ns": "hal/"
+    "protocolGateway": {
+        "adapters": [
+            {
+                "platform": true,
+                "module": {
+                    "name": ".util.mqtt_client",
+                    "class": "MqttProtocolAdapter"
+                },
+                "config": {
+                    "topicNamespace": "hal/",
+                    "brokerUrl": "mqtt://mosquitto:1883"
+                }
+            }
+        ]
     }
 }

--- a/setup/general/iotea/config/config.json
+++ b/setup/general/iotea/config/config.json
@@ -12,7 +12,7 @@
                 },
                 "config": {
                     "topicNamespace": "iotea/",
-                    "brokerUrl": "mqtt://mosquitto-local:1883"
+                    "brokerUrl": "mqtt://mosquitto:1883"
                 }
             }
         ]

--- a/setup/general/iotea/config/config.json
+++ b/setup/general/iotea/config/config.json
@@ -2,9 +2,20 @@
     "loglevel": "DEBUG",
     "platformId": "ABCDE",
     "talentDiscoveryIntervalMs": 30000,
-    "mqtt": {
-        "connectionString": "mqtt://localhost:1883",
-        "ns": "iotea/"
+    "protocolGateway": {
+        "adapters": [
+            {
+                "platform": true,
+                "module": {
+                    "name": "./util/mqttClient",
+                    "class": "MqttProtocolAdapter"
+                },
+                "config": {
+                    "topicNamespace": "iotea/",
+                    "brokerUrl": "mqtt://mosquitto-local:1883"
+                }
+            }
+        ]
     },
     "api": {
         "port": 8080,

--- a/setup/general/kuksa.val/generate-config.sh
+++ b/setup/general/kuksa.val/generate-config.sh
@@ -93,6 +93,6 @@ echo "### Modified file: $CONFIG_DIR/vss-mod.json"
 echo
 
 echo "Execute the following command to install modified vss.json"
-echo "  cp config/vss-mod.json ../../../docker-compose/config/kuksa.val/vss.json"
-echo "  cp -r config/certs ../../../docker-compose/config/kuksa.val/"
+echo "  cp $CONFIG_DIR/vss-mod.json ../../../docker-compose/config/kuksa.val/vss.json"
+echo "  cp -r $CONFIG_DIR/certs ../../../docker-compose/config/kuksa.val/"
 

--- a/setup/general/kuksa.val/generate-config.sh
+++ b/setup/general/kuksa.val/generate-config.sh
@@ -93,6 +93,6 @@ echo "### Modified file: $CONFIG_DIR/vss-mod.json"
 echo
 
 echo "Execute the following command to install modified vss.json"
-echo "  cp vss-mod.json ../../../docker-compose/config/kuksa.val/vss.json"
-echo "  cp -r certs ../../../docker-compose/config/kuksa.val/"
+echo "  cp config/vss-mod.json ../../../docker-compose/config/kuksa.val/vss.json"
+echo "  cp -r config/certs ../../../docker-compose/config/kuksa.val/"
 

--- a/setup/general/kuksa.val2iotea/config/config.json
+++ b/setup/general/kuksa.val2iotea/config/config.json
@@ -1,8 +1,19 @@
 {
-    "loglevel": "DEBUG",
-    "mqtt": {
-        "connectionString": "mqtt://localhost:1883",
-        "ns": "iotea/"
+    "loglevel": "INFO",
+    "protocolGateway": {
+        "adapters": [
+            {
+                "platform": true,
+                "module": {
+                    "name": "./util/mqttClient",
+                    "class": "MqttProtocolAdapter"
+                },
+                "config": {
+                    "topicNamespace": "iotea/",
+                    "brokerUrl": "mqtt://mosquitto-local:1883"
+                }
+            }
+        ]
     },
     "kuksa.val": {
         "ws": "ws://localhost:8090",

--- a/setup/general/kuksa.val2iotea/config/config.json
+++ b/setup/general/kuksa.val2iotea/config/config.json
@@ -10,14 +10,14 @@
                 },
                 "config": {
                     "topicNamespace": "iotea/",
-                    "brokerUrl": "mqtt://mosquitto-local:1883"
+                    "brokerUrl": "mqtt://mosquitto:1883"
                 }
             }
         ]
     },
     "kuksa.val": {
-        "ws": "ws://localhost:8090",
-        "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJrdWtzYS52YWwiLCJpc3MiOiJFY2xpcHNlIEtVS1NBIERldiIsImFkbWluIjp0cnVlLCJtb2RpZnlUcmVlIjp0cnVlLCJpYXQiOjE1MTYyMzkwMjIsImV4cCI6MTc2NzIyNTU5OSwia3Vrc2EtdnNzIjp7IioiOiJydyJ9fQ.p2cnFGH16QoQ14l6ljPVKggFXZKmD-vrw8G6Vs6DvAokjsUG8FHh-F53cMsE-GDjyZH_1_CrlDCnbGlqjsFbgAylqA7IAJWp9_N6dL5p8DHZTwlZ4IV8L1CtCALs7XVqvcQKHCCzB63Y8PgVDCAqpQSRb79JPVD4pZwkBKpOknfEY5y9wfbswZiRKdgz7o61_oFnd-yywpse-23HD6v0htThVF1SuGL1PuvGJ8p334nt9bpkZO3gaTh1xVD_uJMwHzbuBCF33_f-I5QMZO6bVooXqGfe1zvl3nDrPEjq1aPulvtP8RgREYEqE6b2hB8jouTiC_WpE3qrdMw9sfWGFbm04qC-2Zjoa1yYSXoxmYd0SnliSYHAad9aXoEmFENezQV-of7sc-NX1-2nAXRAEhaqh0IRuJwB4_sG7SvQmnanwkz-sBYxKqkoFpOsZ6hblgPDOPYY2NAsZlYkjvAL2mpiInrsmY_GzGsfwPeAx31iozImX75rao8rm-XucAmCIkRlpBz6MYKCjQgyRz3UtZCJ2DYF4lKqTjphEAgclbYZ7KiCuTn9HualwtEmVzHHFneHMKl7KnRQk-9wjgiyQ5nlsVpCCblg6JKr9of4utuPO3cBvbjhB4_ueQ40cpWVOICcOLS7_w0i3pCq1ZKDEMrYDJfz87r2sU9kw1zeFQk"
+        "ws": "ws://kuksa.val:8090",
+        "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJrdWtzYS52YWwiLCJpc3MiOiJFY2xpcHNlIEtVS1NBIERldiIsImFkbWluIjp0cnVlLCJtb2RpZnlUcmVlIjp0cnVlLCJpYXQiOjE1MTYyMzkwMjIsImV4cCI6MTY1NDY4ODE2NSwia3Vrc2EtdnNzIjp7IioiOiJydyJ9fQ.CsTbYO_Xb8EmPU5PWKmsBpbx9LoOQXZjL9NwdEKrDR4g-Ky1vAQ5Rrst17gTb3zEUWNC2-UbVPNA38qttCrN3f2uQTTFQbevx2UVP42OWzbddUplAAcjxTvz3kGmQxKeR8Ijs7fPCHogK_nw9V9O9FO2cGPfKVrhV_JpD5sf9iM_RfbqwyWjBJ3Vo7zj5slWnFD9w6MZdAQbBVp_QjYJwH5B02QFJ0AS7urmCgInRnzxjayH_Z74Bu1RROrUxe1HyCPMcd8xnlTcoh-wCxotYj-Rg3t9mQY2ywG59Bq0T1pMocJ_5Jx4_5zSNF2JU3H8FL_iP0OjzljoBpK89qzOVYVepEmAo9W6ze1JXjxQo5WH6C0fsjo6gJMVCJ5fnUCm5cP6FPIwV_pN00bQKrFxulGP7gigSO2a__CDv4EdbdquJPktSK4LtAO0MqFbWxPlkggnwz59fqqCaJ1fpcywtkRWHCCui3a80eE7wllGthGkNhjqB9a4xB8DOYzpMYjhmY9_E5WvXY4WHq_rTTpHhKf3xja66Z8y4NVp_P4a7_gWy8LRzQThdX2wpXosVRPFsa2dHjSL4bwvSi_tdgkRajXI6G2KFMFkbrWP6hfab5GhIOKDOp2TNp0b5Ff2vJsuqfQrBVF63NzefKMNYNc0NT_CfVwQDtZJkLegZDaV1JU"
     },
     "segment": "280101",
     "paths": {

--- a/src/edge.hal-interface-adapter/src/halInterfaceAdapter.js
+++ b/src/edge.hal-interface-adapter/src/halInterfaceAdapter.js
@@ -163,7 +163,7 @@ module.exports = class HalInterfaceAdapter {
     async __onHalMessageReceive(msg, topic) {
         this.logger.debug(`Received HAL message ${JSON.stringify(msg)} for topic ${topic}`);
 
-        // Receives 10.CruiseStatus2
+        // Receives topic like '10.CruiseStatus2'
         try {
             const entry = this.lut.resolveEntryByHalResourceId(topic);
             const messageModel = new JsonModel(msg);

--- a/src/edge.hal-interface/src/hal_interface.py
+++ b/src/edge.hal-interface/src/hal_interface.py
@@ -483,7 +483,7 @@ class HalInterface:
             if bus_config['interface'] == 'mock':
                 bus_observer = MockBusObserver(bus_config, self.protocol_gateway)
             else:
-                bus_observer = BusObserver(bus_config, self.broker)
+                bus_observer = BusObserver(bus_config, self.protocol_gateway)
 
             self.bus_observer.append(bus_observer)
             await bus_observer.start()

--- a/src/edge.hal-interface/src/hal_interface.py
+++ b/src/edge.hal-interface/src/hal_interface.py
@@ -356,7 +356,7 @@ class MockSignalGenerator:
 
 class MockBusObserver(BusObserver):
     def __init__(self, bus_config, protocol_gateway):
-        super(MockBusObserver, self).__init__(bus_config, protocol_gateway)
+        super().__init__(bus_config, protocol_gateway)
 
         # pylint: disable=anomalous-backslash-in-string
         self.topic_regex = re.compile('([^\.]+)\.(.+)\/(?:start|stop)$')
@@ -494,7 +494,7 @@ class HalInterface:
 
     async def init_protocol_gateway(self):
         self.protocol_gateway = ProtocolGateway(self.config['protocolGateway'], 'HalInterface-{}'.format(id(self)), True)
-        if len(self.config['protocolGateway']['adapters']) is not 1:
+        if len(self.config['protocolGateway']['adapters']) != 1:
             raise Exception('Invalid ProtocolGateway Configuration: only one adapter is allowed!')
 
         # pylint: disable=anomalous-backslash-in-string


### PR DESCRIPTION
The code in this feature branch depends on https://github.com/GENIVI/iot-event-analytics/pull/58 and the strip namespace fix in https://github.com/boschglobal/iot-event-analytics/tree/feature/python-unit-test-setup.

Signed-off-by: Maria Ivanova <maria.ivanova@bosch.io>